### PR TITLE
Traintruck of changes: File and folder path verification, quote path is accepted, and 2 other small changes

### DIFF
--- a/MPNWorkshopUploader/Program.cs
+++ b/MPNWorkshopUploader/Program.cs
@@ -11,56 +11,56 @@ using System.Text.RegularExpressions;
 
 namespace MPNWorkshopUploader
 {
-	public static class ImageClassifier
+    public static class ImageClassifier
+    {
+	public enum ImageFormat
 	{
-		public enum ImageFormat
-		{
-			jpeg,
-			gif,
-			png,
-			unknown
-		}
-
-		public static ImageFormat GetImageFormat(byte[] bytes)
-		{
-			// see http://www.mikekunz.com/image_file_header.html  
-			var gif = Encoding.ASCII.GetBytes("GIF");    // GIF
-			var png = new byte[] { 137, 80, 78, 71 };    // PNG
-			var jpeg = new byte[] { 255, 216, 255, 224 }; // jpeg
-			var jpeg2 = new byte[] { 255, 216, 255, 225 }; // jpeg cano
-
-			if (gif.SequenceEqual(bytes.Take(gif.Length)))
-				return ImageFormat.gif;
-
-			if (png.SequenceEqual(bytes.Take(png.Length)))
-				return ImageFormat.png;
-
-			if (jpeg.SequenceEqual(bytes.Take(jpeg.Length)))
-				return ImageFormat.jpeg;
-
-			if (jpeg2.SequenceEqual(bytes.Take(jpeg2.Length)))
-				return ImageFormat.jpeg;
-
-			return ImageFormat.unknown;
-		}
+	jpeg,
+	gif,
+	png,
+	unknown
 	}
+
+	public static ImageFormat GetImageFormat(byte[] bytes)
+	{
+	    // see http://www.mikekunz.com/image_file_header.html  
+	    var gif = Encoding.ASCII.GetBytes("GIF");    // GIF
+	    var png = new byte[] { 137, 80, 78, 71 };    // PNG
+	    var jpeg = new byte[] { 255, 216, 255, 224 }; // jpeg
+	    var jpeg2 = new byte[] { 255, 216, 255, 225 }; // jpeg cano
+
+	    if (gif.SequenceEqual(bytes.Take(gif.Length)))
+	    return ImageFormat.gif;
+   
+	    if (png.SequenceEqual(bytes.Take(png.Length)))
+    	    return ImageFormat.png;
+
+	    if (jpeg.SequenceEqual(bytes.Take(jpeg.Length)))
+	    return ImageFormat.jpeg;
+
+	    if (jpeg2.SequenceEqual(bytes.Take(jpeg2.Length)))
+	    return ImageFormat.jpeg;
+
+	    return ImageFormat.unknown;
+	}
+    }
 	//Thanks Facepunch for the code
-	public class TrackUpload : IProgress<float>
+    public class TrackUpload : IProgress<float>
+    {
+	float lastvalue = 0;
+
+	public void Report(float value)
 	{
-		float lastvalue = 0;
+	    if (lastvalue >= value) return;
 
-		public void Report(float value)
-		{
-			if (lastvalue >= value) return;
+	    lastvalue = value;
 
-			lastvalue = value;
-
-			Console.WriteLine("Uploading progress: " + (value * 100).ToString() + "%");
-		}
+	    Console.WriteLine("Uploading progress: " + (value * 100).ToString() + "%");
 	}
+    }
 
-	internal class Program
-	{
+    internal class Program
+    {
         public static string CheckFilePathQuotes(string path)
         {
             string pattern = @"""(.*?)""";
@@ -73,65 +73,66 @@ namespace MPNWorkshopUploader
         }
 
         public static string VerifyIconPath(string path)
-		{
+	{
             if (File.Exists(path))
-			{
-                if (ImageClassifier.GetImageFormat(File.ReadAllBytes(path)) == ImageClassifier.ImageFormat.unknown)
-				{
-					return "File type is not valid!";
-				} else
-				{
-					return "";
-				}
-			}
-			return "File path is not valid!";
-		}
-
-		public static string GetImagePath(bool updating=false)
+	    {
+		if (ImageClassifier.GetImageFormat(File.ReadAllBytes(path)) == ImageClassifier.ImageFormat.unknown)
 		{
-			string path = string.Empty;
-			while(true)
-			{
-				path = Console.ReadLine();
+		    return "File type is not valid!";
+		} 
+                else 
+                {
+		    return "";
+		}
+	    }
+	    return "File path is not valid!";
+	}
+	
+        public static string GetImagePath(bool updating = false)
+        {
+            string path = string.Empty;
+	    while(true)
+	    {
+		path = Console.ReadLine();
                 path = CheckFilePathQuotes(path);
 
                 if (path == "" && updating)
-				{
-					break;
-				}
-				string errorMessage = VerifyIconPath(path);
-				if (errorMessage.Length != 0)
-				{
-					Console.WriteLine(errorMessage);
-					Console.Write("Icon path (absolute, quotes are fine in your path): ");
-				}
-				else
-				{
+		{
+		    break;
+		}
+		string errorMessage = VerifyIconPath(path);
+		if (errorMessage.Length != 0)
+		{
+		    Console.WriteLine(errorMessage);
+		    Console.Write("Icon path (absolute, quotes are fine in your path): ");
+		} 
+                else 
+                {
                     Console.WriteLine("Path chosen: {0}", path);
                     break;
-				}
-			}
-			return path;
 		}
+	    }
+	return path;
+	}
 
-		public static string GetContentPath(bool updating = false)
-		{
+	public static string GetContentPath(bool updating = false)
+	{
             string path = string.Empty;
             while (true)
             {
                 path = Console.ReadLine();
-				path = CheckFilePathQuotes(path);
+                path = CheckFilePathQuotes(path);
 
                 if (path == "" && updating)
                 {
                     break;
-				}
+                }
                 if (Path.GetExtension(path) == string.Empty)
                 {
                     Console.WriteLine("Folder path is invalid!");
                     Console.Write("Content path (absolute, quotes are fine in your path): ");
-                }
-                else
+                } 
+                else 
                 {
                     Console.WriteLine("Path chosen: {0}", path);
                     break;
@@ -140,200 +141,200 @@ namespace MPNWorkshopUploader
             return path;
         }
 
-		static async Task Main(string[] args)
-		{
-			try
-			{
-				//Steam init
-				SteamClient.Init(488860, true);
+	static async Task Main(string[] args)
+	{
+	    try
+	    {
+		//Steam init
+		SteamClient.Init(488860, true);
 
-				//Console Init
-				Console.Clear();
-				Console.ForegroundColor = ConsoleColor.Red;
-
-
-				//Cool intro text
-				Console.WriteLine("Madness: Project Nexus Workshop Uploader");
-				Console.WriteLine("Copyrighted 1982-1996 2BDamned & Twingamerdudes");
-				Console.WriteLine();
-
-				Console.WriteLine("Are you updating or creating a new mod? (update/create)");
-				string updateStr = Console.ReadLine();
-				bool updating = updateStr.ToLower() == "update";
+		//Console Init
+		Console.Clear();
+                Console.ForegroundColor = ConsoleColor.Red;
 
 
-				if (!updating)
-				{
-					//Getting mod info
-					Console.Write("Mod name: ");
-					string name = Console.ReadLine();
-					Console.Write("Mod description: ");
-					string description = Console.ReadLine();
-					Console.Write("Icon path (absolute, quotes are fine in your path): ");
-					string iconPath = GetImagePath();
-					Console.Write("Content path (absolute, quotes are fine in your path): ");
-					string path = GetContentPath();
+                //Cool intro text
+                Console.WriteLine("Madness: Project Nexus Workshop Uploader");
+                Console.WriteLine("Copyrighted 1982-1996 2BDamned & Twingamerdudes");
+                Console.WriteLine();
+
+                Console.WriteLine("Are you updating or creating a new mod? (update/create)");
+                string updateStr = Console.ReadLine();
+                bool updating = updateStr.ToLower() == "update";
+
+
+                if (!updating)
+                {
+                    //Getting mod info
+                    Console.Write("Mod name: ");
+		    string name = Console.ReadLine();
+                    Console.Write("Mod description: ");
+                    string description = Console.ReadLine();
+                    Console.Write("Icon path (absolute, quotes are fine in your path): ");
+                    string iconPath = GetImagePath();
+                    Console.Write("Content path (absolute, quotes are fine in your path): ");
+                    string path = GetContentPath();
                     Console.Write("Tags (comma separated): ");
-					string tags = Console.ReadLine();
+                    string tags = Console.ReadLine();
 
-					Console.WriteLine("Are you sure you want to upload this? (y/n)");
-					string confirm = Console.ReadLine();
-					bool confirmed = confirm.ToLower() != "y";
+                    Console.WriteLine("Are you sure you want to upload this? (y/n)");
+                    string confirm = Console.ReadLine();
+                    bool confirmed = confirm.ToLower() != "y";
 
-					if (confirmed)
-					{
-						Environment.Exit(0);
-					}
+                    if (confirmed)
+		    {
+                        Environment.Exit(0);
+		    }
 
-					//Creating mod item
-					var item = Ugc.Editor.NewCommunityFile
-						.WithTitle(name)
-						.WithDescription(description)
-						.WithContent(path)
-						.WithPreviewFile(iconPath);
+                    //Creating mod item
+                    var item = Ugc.Editor.NewCommunityFile
+		    .WithTitle(name)
+		    .WithDescription(description)
+		    .WithContent(path)
+		    .WithPreviewFile(iconPath);
 
-					//Tag parsing
-					foreach (string tag in tags.Split(','))
-					{
-						item.WithTag(tag);
-					}
+                    //Tag parsing
+                    foreach (string tag in tags.Split(','))
+		    {
+			item.WithTag(tag);
+		    }
 
-					Console.Clear();
-					Console.ForegroundColor = ConsoleColor.Red;
+		    Console.Clear();
+		    Console.ForegroundColor = ConsoleColor.Red;
 
-					await upload(item);
-				}
-				else
-				{
-					//Getting mod info
-					Console.Write("Workshop Item ID: ");
-					ulong IDInt = 0;
-					PublishedFileId ID = new PublishedFileId();
+		    await upload(item);
+		}
+		else
+		{
+                    //Getting mod info
+                    Console.Write("Workshop Item ID: ");
+                    ulong IDInt = 0;
+                    PublishedFileId ID = new PublishedFileId();
 
 
-					//Get the ID until a valid one is provided
-					while (true)
-					{
-						string id = Console.ReadLine();
-						if (ulong.TryParse(id, out var parsedID))
-						{
-							IDInt = parsedID;
-							ID.Value = IDInt;
+                    //Get the ID until a valid one is provided
+                    while (true)
+                    {
+                        string id = Console.ReadLine();
+                        if (ulong.TryParse(id, out var parsedID))
+                        {
+                            IDInt = parsedID;
+                            ID.Value = IDInt;
 
-							var q = await Ugc.Query.Items.WithFileId(new PublishedFileId[] { ID }).WithType(UgcType.Items).GetPageAsync(1);
-							if (q.Value.Entries.First().Owner.Name != string.Empty)
-							{
-								break;
-							}
-						}
-						Console.WriteLine("INVALID ID");
-						Console.Write("Workshop Item ID: ");
-					}
+                            var q = await Ugc.Query.Items.WithFileId(new PublishedFileId[] { ID }).WithType(UgcType.Items).GetPageAsync(1);
+                            if (q.Value.Entries.First().Owner.Name != string.Empty)
+                            {
+                                break;
+                            }
+                        }
+                        Console.WriteLine("INVALID ID");
+                        Console.Write("Workshop Item ID: ");
+                    }
 
-					Console.Write("Mod description (leave blank to not change): ");
-					string description = Console.ReadLine();
-					Console.Write("Icon path (absolute, quotes are fine in your path, leave blank to not change): ");
+                    Console.Write("Mod description (leave blank to not change): ");
+                    string description = Console.ReadLine();
+                    Console.Write("Icon path (absolute, quotes are fine in your path, leave blank to not change): ");
                     string iconPath = GetImagePath(true);
                     Console.Write("Content path (absolute, quotes are fine in your path, leave blank to not change content of your mod): ");
                     string path = GetContentPath(true);
-					Console.Write("Tags (comma separated, leave blank to not change): ");
-					string tags = Console.ReadLine();
-					Console.Write("Update notes: ");
-					string updateNotes = Console.ReadLine();
+                    Console.Write("Tags (comma separated, leave blank to not change): ");
+                    string tags = Console.ReadLine();
+                    Console.Write("Update notes: ");
+                    string updateNotes = Console.ReadLine();
 
 
-					//Get mod based on ID
-					var item = new Ugc.Editor(ID)
-						.WithChangeLog(updateNotes);
+                    //Get mod based on ID
+                    var item = new Ugc.Editor(ID)
+                    .WithChangeLog(updateNotes);
 
-					var q2 = await Ugc.Query.Items.WithFileId(new PublishedFileId[] { ID }).WithType(UgcType.Items).GetPageAsync(1);
-					var itemData = q2.Value.Entries.First();
+                    var q2 = await Ugc.Query.Items.WithFileId(new PublishedFileId[] { ID }).WithType(UgcType.Items).GetPageAsync(1);
+                    var itemData = q2.Value.Entries.First();
 
-					//Update it with the new info
-					if (description != "")
-					{
-						item.WithDescription(description);
-					}
+                    //Update it with the new info
+                    if (description != "")
+                    {
+                        item.WithDescription(description);
+                    }
 
-					if (iconPath != "")
-					{
-						item.WithPreviewFile(iconPath);
-					}
+                    if (iconPath != "")
+                    {
+                        item.WithPreviewFile(iconPath);
+                    }
 
-					if (path != "")
-					{
-						item.WithContent(path);
-					}
+                    if (path != "")
+                    {
+                        item.WithContent(path);
+                    }
 
-					//Tag parsing
-					if (tags.Split(',').Length > 0) {
-						foreach (string tag in tags.Split(','))
-						{
-							item.WithTag(tag);
-						}
-					}
-					else
-					{
-						if (itemData.Tags.Length > 0)
-						{
-							foreach (string tag in itemData.Tags)
-							{
-								item.WithTag(tag);
-							}
-						}
-					}
+                    //Tag parsing
+                    if (tags.Split(',').Length > 0) {
+                        foreach (string tag in tags.Split(','))
+                        {
+                            item.WithTag(tag);
+                        }
+                    }
+                    else
+                    {
+                        if (itemData.Tags.Length > 0)
+                        {
+                            foreach (string tag in itemData.Tags)
+                            {
+                                item.WithTag(tag);
+                            }
+                        }
+                    }
 
-					Console.Clear();
-					Console.ForegroundColor = ConsoleColor.Red;
+                    Console.Clear();
+                    Console.ForegroundColor = ConsoleColor.Red;
 
-					await upload(item);
-				}
+                    await upload(item);
+                }
 
-				//Cleanup steam
-				SteamClient.Shutdown();
-			}
-			catch (Exception e)
-			{
-				Console.WriteLine("Well shit");
-				Console.WriteLine(e.Message);
-				Console.ReadLine();
-				Environment.Exit(0);
-			}
+                //Cleanup steam
+                SteamClient.Shutdown();
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine("Well shit");
+                Console.WriteLine(e.Message);
+                Console.ReadLine();
+                Environment.Exit(0);
+            }
 
 
-			Console.WriteLine("Upload success. Press key to exit");
-			Console.ReadLine();
-			Environment.Exit(0);
-		}
+            Console.WriteLine("Upload success. Press key to exit");
+	    Console.ReadLine();
+	    Environment.Exit(0);
+        }
 
-		public static async Task upload(Ugc.Editor item)
-		{
-			//Cool little Madness Combat themed text
-			Console.WriteLine("Upload Process running.");
-			await Task.Delay(100);
-			Console.WriteLine("Improbability Drive found");
-			await Task.Delay(50);
-			Console.WriteLine("Starting upload");
-			Console.WriteLine("Current server: Other_World_001");
+        public static async Task upload(Ugc.Editor item)
+        {
+            //Cool little Madness Combat themed text
+            Console.WriteLine("Upload Process running.");
+            await Task.Delay(100);
+            Console.WriteLine("Improbability Drive found");
+            await Task.Delay(50);
+            Console.WriteLine("Starting upload");
+            Console.WriteLine("Current server: Other_World_001");
 
-			var result = await item.SubmitAsync(new TrackUpload());
+            var result = await item.SubmitAsync(new TrackUpload());
 
-			//Upload fails
-			if (result.Result != Result.OK)
-			{
-				switch (result.Result)
-				{
-					case Result.Fail:
-						Console.WriteLine("ERR: Upload failed, what the fuck did you do Jebus.");
-						break;
-					default:
-						Console.WriteLine("ERR: " + result.Result);
-						break;
-				}
-				Console.WriteLine("Press key to exit");
-				Console.ReadLine();
-				Environment.Exit(1);
-			}
-		}
-	}
+            //Upload fails
+            if (result.Result != Result.OK)
+            {
+                switch (result.Result)
+                {
+                    case Result.Fail:
+                        Console.WriteLine("ERR: Upload failed, what the fuck did you do Jebus.");
+                        break;
+                    default:
+                        Console.WriteLine("ERR: " + result.Result);
+                        break;
+                }
+                Console.WriteLine("Press key to exit");
+                Console.ReadLine();
+                Environment.Exit(1);
+            }
+        }
+    }
 }

--- a/MPNWorkshopUploader/Program.cs
+++ b/MPNWorkshopUploader/Program.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Diagnostics;
+using System.Text.RegularExpressions;
 
 namespace MPNWorkshopUploader
 {
@@ -60,16 +61,30 @@ namespace MPNWorkshopUploader
 
 	internal class Program
 	{
-		public static bool VerifyIconPath(string path)
+        public static string CheckFilePathQuotes(string path)
+        {
+            string pattern = @"""(.*?)""";
+            String[] Match = Regex.Split(path, pattern);
+            if (Match.Length != 1)
+            {
+                path = Match[1];
+            }
+            return path;
+        }
+
+        public static string VerifyIconPath(string path)
 		{
-			if (File.Exists(path))
+            if (File.Exists(path))
 			{
-				if(ImageClassifier.GetImageFormat(File.ReadAllBytes(path)) != ImageClassifier.ImageFormat.unknown)
+                if (ImageClassifier.GetImageFormat(File.ReadAllBytes(path)) == ImageClassifier.ImageFormat.unknown)
 				{
-					return true;
+					return "File type is not valid!";
+				} else
+				{
+					return "";
 				}
 			}
-			return false;
+			return "File path is not valid!";
 		}
 
 		public static string GetImagePath(bool updating=false)
@@ -78,24 +93,52 @@ namespace MPNWorkshopUploader
 			while(true)
 			{
 				path = Console.ReadLine();
+                path = CheckFilePathQuotes(path);
 
-				if (path == "" && updating)
+                if (path == "" && updating)
 				{
 					break;
 				}
-
-				if (!VerifyIconPath(path))
+				string errorMessage = VerifyIconPath(path);
+				if (errorMessage.Length != 0)
 				{
-					Console.WriteLine("IMAGE PATH NOT VALID!!!");
-					Console.Write("Icon path (absolute, don't use quotes in your path): ");
+					Console.WriteLine(errorMessage);
+					Console.Write("Icon path (absolute, quotes are fine in your path): ");
 				}
 				else
 				{
-					break;
+                    Console.WriteLine("Path chosen: {0}", path);
+                    break;
 				}
 			}
 			return path;
 		}
+
+		public static string GetContentPath(bool updating = false)
+		{
+            string path = string.Empty;
+            while (true)
+            {
+                path = Console.ReadLine();
+				path = CheckFilePathQuotes(path);
+
+                if (path == "" && updating)
+                {
+                    break;
+				}
+                if (Path.GetExtension(path) == string.Empty)
+                {
+                    Console.WriteLine("Folder path is invalid!");
+                    Console.Write("Content path (absolute, quotes are fine in your path): ");
+                }
+                else
+                {
+                    Console.WriteLine("Path chosen: {0}", path);
+                    break;
+                }	
+            }
+            return path;
+        }
 
 		static async Task Main(string[] args)
 		{
@@ -126,11 +169,11 @@ namespace MPNWorkshopUploader
 					string name = Console.ReadLine();
 					Console.Write("Mod description: ");
 					string description = Console.ReadLine();
-					Console.Write("Icon path (absolute, don't use quotes in your path): ");
+					Console.Write("Icon path (absolute, quotes are fine in your path): ");
 					string iconPath = GetImagePath();
-					Console.Write("Content path (absolute, don't use quotes in your path): ");
-					string path = Console.ReadLine();
-					Console.Write("Tags (comma separated): ");
+					Console.Write("Content path (absolute, quotes are fine in your path): ");
+					string path = GetContentPath();
+                    Console.Write("Tags (comma separated): ");
 					string tags = Console.ReadLine();
 
 					Console.WriteLine("Are you sure you want to upload this? (y/n)");
@@ -189,10 +232,10 @@ namespace MPNWorkshopUploader
 
 					Console.Write("Mod description (leave blank to not change): ");
 					string description = Console.ReadLine();
-					Console.Write("Icon path (absolute, don't use quotes in your path, leave blank to not change): ");
-					string iconPath = GetImagePath(true);
-					Console.Write("Content path (absolute, don't use quotes in your path, leave blank to not change content of your mod): ");
-					string path = Console.ReadLine();
+					Console.Write("Icon path (absolute, quotes are fine in your path, leave blank to not change): ");
+                    string iconPath = GetImagePath(true);
+                    Console.Write("Content path (absolute, quotes are fine in your path, leave blank to not change content of your mod): ");
+                    string path = GetContentPath(true);
 					Console.Write("Tags (comma separated, leave blank to not change): ");
 					string tags = Console.ReadLine();
 					Console.Write("Update notes: ");


### PR DESCRIPTION
1. VerifyIconPath now returns 2 different error messages depending if the file path or the image type is invalid (lines 75-89)
3. Added a new function called "CheckFilePathQuotes", takes in the parameter "path" and if any quotes are detected using RegEx, they're splitted off from the string remaining only the path (Makes it so you can copy and paste absolute paths without removing quotes) (lines 64-73, implemented in lines 97 and 124)
4. Added new function called "GetContentPath" that works the same way "GetImagePath" does, checking if folder path is valid, skipping if the update value is true and and removing quotes from file paths (lines 118-142, implemented in lines 176 and 239)
5. "GetImagePath" and "GetContentPath" both print the un-quoted path file for clarification (lines 111 and 137)
6. Changed indentation from tabs (8 character spaces) to spaces (4 character spaces)